### PR TITLE
Add basic Tox testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ zxbasmtab.py
 zxbpptab.py
 .idea
 zxbtab.py
+.tox/

--- a/README
+++ b/README
@@ -36,6 +36,30 @@ For Windows users there is also a binary .MSI installation, which does not need
 python installed.
 
 
+TESTING
+-------
+
+You will need to get Tox in order to run the project tests. Normally it is done
+by calling:
+
+~~~~
+$ pip install tox
+~~~~
+
+inside a Virtual Environment ( https://virtualenv.pypa.io/en/stable/ ).
+
+Please, see https://tox.readthedocs.io/en/latest/install.html for more
+information about installing Tox.
+
+Once you have installed Tox, just call:
+
+~~~~
+$ tox
+~~~~
+
+to get your tests running.
+
+
 AKNOWLEDGEMENTS
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ For Windows users there is also a binary .MSI installation, which does not need
 python installed.
 
 
+TESTING
+-------
+
+You will need to get Tox in order to run the project tests. Normally it is done
+by calling:
+
+~~~~
+$ pip install tox
+~~~~
+
+inside a Virtual Environment ( https://virtualenv.pypa.io/en/stable/ ).
+
+Please, see https://tox.readthedocs.io/en/latest/install.html for more
+information about installing Tox.
+
+Once you have installed Tox, just call:
+
+~~~~
+$ tox
+~~~~
+
+to get your tests running.
+
+
 AKNOWLEDGEMENTS
 ---------------
 

--- a/tests/api/test_symbolTable.py
+++ b/tests/api/test_symbolTable.py
@@ -5,9 +5,6 @@ import unittest
 from unittest import TestCase
 from six import StringIO
 
-# Initialize import syspath
-import __init__
-
 from api.symboltable import SymbolTable
 from api.constants import TYPE
 from api.constants import SCOPE

--- a/tests/symbols/test_symbolARRAYACCESS.py
+++ b/tests/symbols/test_symbolARRAYACCESS.py
@@ -4,9 +4,6 @@
 from unittest import TestCase
 from six import StringIO
 
-# Initialize import syspath
-import __init__
-
 import arch.zx48k  # initializes arch
 import symbols
 import api.global_ as gl
@@ -93,4 +90,3 @@ class TestSymbolARRAYACCESS(TestCase):
         self.assertIsInstance(aa, symbols.ARRAYACCESS)
         self.assertIsNotNone(aa.offset)
         self.assertEqual(aa.offset, 7)
-

--- a/tests/symbols/test_symbolBASICTYPE.py
+++ b/tests/symbols/test_symbolBASICTYPE.py
@@ -4,9 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 
 from api.constants import TYPE
 from symbols.type_ import SymbolBASICTYPE

--- a/tests/symbols/test_symbolBINARY.py
+++ b/tests/symbols/test_symbolBINARY.py
@@ -4,9 +4,6 @@
 from unittest import TestCase
 from six import StringIO
 
-# Initialize import syspath
-import __init__
-
 from api.config import OPTIONS
 import symbols
 from symbols.type_ import Type

--- a/tests/symbols/test_symbolBLOCK.py
+++ b/tests/symbols/test_symbolBLOCK.py
@@ -6,9 +6,6 @@ from unittest import TestCase
 from symbols import BLOCK
 from symbols import NUMBER
 
-# Initialize import syspath
-import __init__
-
 __author__ = 'boriel'
 
 

--- a/tests/symbols/test_symbolBOUND.py
+++ b/tests/symbols/test_symbolBOUND.py
@@ -5,9 +5,6 @@ import unittest
 from unittest import TestCase
 from six import StringIO
 
-# Initialize import syspath
-import __init__
-
 from api.config import OPTIONS
 import symbols
 

--- a/tests/symbols/test_symbolBOUNDLIST.py
+++ b/tests/symbols/test_symbolBOUNDLIST.py
@@ -4,9 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 import symbols
 
 class TestSymbolBOUNDLIST(TestCase):

--- a/tests/symbols/test_symbolFUNCDECL.py
+++ b/tests/symbols/test_symbolFUNCDECL.py
@@ -6,9 +6,6 @@ from unittest import TestCase
 import api.global_ as gl
 import api.symboltable
 
-# Initialize import syspath
-import __init__
-
 from symbols import FUNCDECL
 from symbols.type_ import Type
 

--- a/tests/symbols/test_symbolFUNCTION.py
+++ b/tests/symbols/test_symbolFUNCTION.py
@@ -4,9 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 import symbols
 from api.constants import CLASS
 

--- a/tests/symbols/test_symbolNUMBER.py
+++ b/tests/symbols/test_symbolNUMBER.py
@@ -4,9 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 from api.constants import TYPE
 from symbols import NUMBER
 from symbols import BASICTYPE

--- a/tests/symbols/test_symbolSENTENCE.py
+++ b/tests/symbols/test_symbolSENTENCE.py
@@ -3,9 +3,6 @@
 
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 import symbols
 
 class TestSymbolSENTENCE(TestCase):

--- a/tests/symbols/test_symbolSTRING.py
+++ b/tests/symbols/test_symbolSTRING.py
@@ -4,9 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 import symbols
 from symbols.type_ import Type
 

--- a/tests/symbols/test_symbolSTRSLICE.py
+++ b/tests/symbols/test_symbolSTRSLICE.py
@@ -4,8 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
 import symbols
 import api.global_ as gl
 

--- a/tests/symbols/test_symbolTYPE.py
+++ b/tests/symbols/test_symbolTYPE.py
@@ -4,8 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
 from api.constants import TYPE
 from symbols.type_ import SymbolTYPE
 from symbols.type_ import SymbolBASICTYPE

--- a/tests/symbols/test_symbolTYPEALIAS.py
+++ b/tests/symbols/test_symbolTYPEALIAS.py
@@ -4,9 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 from api.constants import TYPE
 from symbols.type_ import SymbolBASICTYPE
 from symbols.type_ import SymbolTYPEALIAS

--- a/tests/symbols/test_symbolTYPECAST.py
+++ b/tests/symbols/test_symbolTYPECAST.py
@@ -4,10 +4,6 @@ __autor__ = 'boriel'
 
 from unittest import TestCase
 
-
-# Initialize import syspath
-import __init__
-
 from symbols import TYPECAST
 from symbols import NUMBER
 from symbols import VAR

--- a/tests/symbols/test_symbolVAR.py
+++ b/tests/symbols/test_symbolVAR.py
@@ -4,9 +4,6 @@
 import unittest
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 import symbols
 from symbols.type_ import Type
 from api.constants import SCOPE

--- a/tests/symbols/test_symbolVARARRAY.py
+++ b/tests/symbols/test_symbolVARARRAY.py
@@ -3,9 +3,6 @@
 
 from unittest import TestCase
 
-# Initialize import syspath
-import __init__
-
 import api.global_ as gl
 from api.constants import TYPE
 from api.constants import CLASS

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27,py35
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps =
+    pytest
+    nose
+    -rrequirements.txt
+commands =
+    py.test
+    nosetests
+    /bin/bash -c 'cd ./tests/functional && make'


### PR DESCRIPTION
The only supported language at the momment will be
Python27 since Python3 versions are not working
at the momment.