### PR TITLE
bugfix: Fix LET ARR$ substr asignation

### DIFF
--- a/arch/zx48k/translator.py
+++ b/arch/zx48k/translator.py
@@ -364,7 +364,7 @@ class Translator(TranslatorVisitor):
         else:
             offset = node_.offset
             if scope == SCOPE.global_:
-                self.ic_load(gl.PTR_TYPE, entry.t, '%s + %i' % (entry.mangled, offset))
+                self.ic_load(gl.PTR_TYPE, entry.t, '%s.__DATA__ + %i' % (entry.mangled, offset))
             elif scope == SCOPE.parameter:
                 self.ic_pload(gl.PTR_TYPE, node_.t, entry.offset - offset)
             elif scope == SCOPE.local:

--- a/tests/functional/let_array_substr10.asm
+++ b/tests/functional/let_array_substr10.asm
@@ -25,7 +25,7 @@ __START_PROGRAM:
 	push hl
 	ld hl, 3
 	push hl
-	ld hl, (_a + 8)
+	ld hl, (_a.__DATA__ + 8)
 	call __LETSUBSTR
 	ld hl, 0
 	ld b, h

--- a/tests/functional/let_array_substr11.asm
+++ b/tests/functional/let_array_substr11.asm
@@ -25,7 +25,7 @@ __START_PROGRAM:
 	push hl
 	ld hl, 65534
 	push hl
-	ld hl, (_a + 6)
+	ld hl, (_a.__DATA__ + 6)
 	call __LETSUBSTR
 	ld hl, 0
 	ld b, h

--- a/tests/functional/let_array_substr12.asm
+++ b/tests/functional/let_array_substr12.asm
@@ -25,7 +25,7 @@ __START_PROGRAM:
 	push hl
 	ld hl, 5
 	push hl
-	ld hl, (_a + 6)
+	ld hl, (_a.__DATA__ + 6)
 	call __LETSUBSTR
 	ld hl, 0
 	ld b, h

--- a/tests/functional/let_array_substr13.asm
+++ b/tests/functional/let_array_substr13.asm
@@ -25,7 +25,7 @@ __START_PROGRAM:
 	push hl
 	ld hl, 5
 	push hl
-	ld hl, (_a + 6)
+	ld hl, (_a.__DATA__ + 6)
 	call __LETSUBSTR
 	ld hl, 0
 	ld b, h

--- a/tests/functional/let_array_substr2.asm
+++ b/tests/functional/let_array_substr2.asm
@@ -25,7 +25,7 @@ __START_PROGRAM:
 	push hl
 	ld hl, 5
 	push hl
-	ld hl, (_a + 6)
+	ld hl, (_a.__DATA__ + 6)
 	call __LETSUBSTR
 	ld hl, 0
 	ld b, h

--- a/tests/functional/let_array_substr3.asm
+++ b/tests/functional/let_array_substr3.asm
@@ -25,7 +25,7 @@ __START_PROGRAM:
 	push hl
 	ld hl, 5
 	push hl
-	ld hl, (_a + 6)
+	ld hl, (_a.__DATA__ + 6)
 	call __LETSUBSTR
 	ld hl, 0
 	ld b, h

--- a/tests/functional/let_array_substr7.asm
+++ b/tests/functional/let_array_substr7.asm
@@ -25,7 +25,7 @@ __START_PROGRAM:
 	push hl
 	ld hl, 1
 	push hl
-	ld hl, (_a + 6)
+	ld hl, (_a.__DATA__ + 6)
 	call __LETSUBSTR
 	ld hl, 0
 	ld b, h

--- a/tests/functional/let_array_substr9.asm
+++ b/tests/functional/let_array_substr9.asm
@@ -25,7 +25,7 @@ __START_PROGRAM:
 	push hl
 	ld hl, 65534
 	push hl
-	ld hl, (_a + 6)
+	ld hl, (_a.__DATA__ + 6)
 	call __LETSUBSTR
 	ld hl, 0
 	ld b, h


### PR DESCRIPTION
Asignation of substring to an array element of type String was
not working when the index was constant. Fixed.

LET m$(2)(3 TO 5) = "x"

Didn't update m$(2).