### PR TITLE
Fix crash when referencing undeclared arrays

### DIFF
--- a/tests/functional/dim_test0.bas
+++ b/tests/functional/dim_test0.bas
@@ -1,0 +1,6 @@
+
+DIM a AT @c(1, 5)
+DIM c(10, 10) as UBYTE
+
+const q = @c(2, 3)
+

--- a/zxbparser.py
+++ b/zxbparser.py
@@ -622,6 +622,9 @@ def p_var_decl_at(p):
     """
     p[0] = None
 
+    if p[2] is None or p[3] is None or p[5] is None:
+        return
+
     if len(p[2]) != 1:
         syntax_error(p.lineno(1),
                      'Only one variable at a time can be declared this way')


### PR DESCRIPTION
When declaring a variable or constant referencing an address of an
element of an undeclared array, the compiler crashed. Fixed.