### PR TITLE
Bugfix: emmit start label in headless mode

### DIFF
--- a/arch/zx48k/backend/__init__.py
+++ b/arch/zx48k/backend/__init__.py
@@ -2176,13 +2176,13 @@ def emit_start():
     output = list()
     output.append('org %s' % OPTIONS.org.value)
 
-    if OPTIONS.headerless.value:
-        return output
-
     if REQUIRES.intersection(MEMINITS) or '__MEM_INIT' in INITS:
         output.append('; Defines HEAP SIZE\n' + OPTIONS.heap_size_label.value + ' EQU ' + str(OPTIONS.heap_size.value))
 
     output.append('%s:' % START_LABEL)
+    if OPTIONS.headerless.value:
+        return output
+
     output.append('di')
     output.append('push ix')
     output.append('push iy')

--- a/tests/functional/headerless.asm
+++ b/tests/functional/headerless.asm
@@ -1,4 +1,5 @@
 	org 32768
+__START_PROGRAM:
 	ld hl, _a
 	inc (hl)
 	ld hl, 0
@@ -6,7 +7,6 @@
 	ld c, l
 __END_PROGRAM:
 	ret
-
 ZXBASIC_USER_DATA:
 _a:
 	DEFB 02h
@@ -14,4 +14,4 @@ _a:
 ZXBASIC_USER_DATA_END EQU ZXBASIC_MEM_HEAP
 	; Defines USER DATA Length in bytes
 ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_END - ZXBASIC_USER_DATA
-	END
+	END __START_PROGRAM

--- a/tests/functional/headerless.bas
+++ b/tests/functional/headerless.bas
@@ -1,5 +1,6 @@
 REM a headerless (no prologuqe in ASM) program
 #pragma headerless=true
+#pragma autorun=true
 
 DIM a as UByte = 2
 LET a = a + 1


### PR DESCRIPTION
When using the --headerless flag, the autostart was not working.
Fixed.