### PR TITLE
Bugfix: Allow defining empty macros

### DIFF
--- a/tests/functional/test_cmdline.txt
+++ b/tests/functional/test_cmdline.txt
@@ -13,3 +13,5 @@ usage: zxb [-h] [-d] [-O OPTIMIZE] [-o OUTPUT_FILE] [-T] [-t] [-B] [-a] [-A]
            [--append-headless-binary APPEND_HEADLESS_BINARY]
            PROGRAM
 zxb: error: Option --asm and --mmap cannot be used together
+
+>>> process_file('arrbase1.bas', ['-q', '-S', '-O -D EMPTY_MACRO'])

--- a/zxb.py
+++ b/zxb.py
@@ -181,7 +181,9 @@ def main(args=None):
 
     if options.defines:
         for i in options.defines:
-            name, val = tuple(i.split('=', 1))
+            macro = list(i.split('=', 1))
+            name = macro[0]
+            val = ''.join(macro[1:])
             OPTIONS.__DEFINES.value[name] = val
             zxbpp.ID_TABLE.define(name, lineno=0)
 


### PR DESCRIPTION
zxb -D ANYTHING

was crashing. Fixed.