### PR TITLE
Switch from using deprecated zx emulator members.

### DIFF
--- a/tests/runtime/check_test.py
+++ b/tests/runtime/check_test.py
@@ -13,7 +13,7 @@ class Tester(zx.Emulator):
         super().__init__(speed_factor=None)
 
     def on_breakpoint(self):
-        self.done = True
+        self.stop()
 
     def run_test(self, tape_filename, ram_filename):
         # Auto-load the tape.
@@ -23,7 +23,7 @@ class Tester(zx.Emulator):
         self.set_breakpoint(8)
 
         # Run the main loop until self.done is raised.
-        self.main()
+        self.run()
 
         # Get view to the video memory.
         screen = self.get_memory_view(0x4000, 6 * 1024 + 768)

--- a/tests/runtime/update_test.py
+++ b/tests/runtime/update_test.py
@@ -16,7 +16,7 @@ class TakeSnapshot(zx.Emulator):
         super().__init__(speed_factor=None)
 
     def on_breakpoint(self):
-        self.done = True
+        self.stop()
 
     def run_test(self, filename):
         # Auto-load the tape.
@@ -26,7 +26,7 @@ class TakeSnapshot(zx.Emulator):
         self.set_breakpoint(8)
 
         # Run the main loop until self.done is raised.
-        self.main()
+        self.run()
 
         # Get view to the video memory.
         screen = self.get_memory_view(0x4000, 6 * 1024 + 768)


### PR DESCRIPTION
This will allow me to remove/hide the deprecated counterparts. Will need pulling the latest changes from the emulator repo. Sorry for bothering. :-)