### PR TITLE
[Tests] Use exceptions for quitting from the emulation loop.

### DIFF
--- a/tests/runtime/check_test.py
+++ b/tests/runtime/check_test.py
@@ -5,6 +5,10 @@ import sys
 import zx
 
 
+class Stop(Exception):
+    pass
+
+
 class Tester(zx.Emulator):
     def __init__(self):
         # speed_factor=None results in maximum speed and
@@ -13,7 +17,7 @@ class Tester(zx.Emulator):
         super().__init__(speed_factor=None)
 
     def on_breakpoint(self):
-        self.stop()
+        raise Stop
 
     def run_test(self, tape_filename, ram_filename):
         # Auto-load the tape.
@@ -22,8 +26,11 @@ class Tester(zx.Emulator):
         # Catch the end of test.
         self.set_breakpoint(8)
 
-        # Run the main loop until self.done is raised.
-        self.run()
+        # Run the main loop.
+        try:
+            self.run()
+        except Stop:
+            pass
 
         # Get view to the video memory.
         screen = self.get_memory_view(0x4000, 6 * 1024 + 768)

--- a/tests/runtime/update_test.py
+++ b/tests/runtime/update_test.py
@@ -8,6 +8,10 @@ import sys
 import zx
 
 
+class Stop(Exception):
+    pass
+
+
 class TakeSnapshot(zx.Emulator):
     def __init__(self):
         # speed_factor=None results in maximum speed and
@@ -25,13 +29,16 @@ class TakeSnapshot(zx.Emulator):
         # Catch the end of test.
         self.set_breakpoint(8)
 
-        # Run the main loop until self.done is raised.
-        self.run()
+        # Run the main loop.
+        try:
+            self.run()
+        except Stop:
+            pass
 
         # Get view to the video memory.
         screen = self.get_memory_view(0x4000, 6 * 1024 + 768)
 
-        # Compare it with the etalon screenshot.
+        # Take screenshot.
         with open(filename + '.scr', 'wb') as f:
             f.write(screen)
 


### PR DESCRIPTION
This would help to resolve https://github.com/kosarev/zx/issues/10 and make sure we don't even attempt to compare screenshots when the emulation is terminated due to reasons other than hitting the breakpoint, e.g., pressing `F10`.