### PR TITLE
Fix wrong include name file

### DIFF
--- a/api/symboltable.py
+++ b/api/symboltable.py
@@ -218,7 +218,8 @@ class SymbolTable(object):
 
         if result is None or not result.declared:
             if show_error:
-                syntax_error(lineno, 'Undeclared %s "%s"' % (classname, id_))
+                syntax_error(lineno, 'Undeclared %s "%s"' % (classname, id_),
+                             fname=(result.filename if result is not None else None))
             return False
         return True
 

--- a/tests/functional/include_error.bas
+++ b/tests/functional/include_error.bas
@@ -1,0 +1,3 @@
+REM should shouw the original (included) filename, not this one
+
+#include "llb.bas"

--- a/tests/functional/test_errmsg.txt
+++ b/tests/functional/test_errmsg.txt
@@ -158,4 +158,6 @@ dim_at_label6.bas:3: error: Circular dependency between 'c' and 'b'
 dim_at_label7.bas:3: error: Circular dependency between 'b' and 'a'
 dim_at_label7.bas:3: error: Circular dependency between 'a' and 'c'
 dim_at_label7.bas:4: error: Circular dependency between 'c' and 'b'
+>>> process_file('include_error.bas')
+llb.bas:3: error: Undeclared function "f$"
 


### PR DESCRIPTION
This happened when resolving pending calls. Filename
must be that of the variable (where the variable is
being referenced, not the current main file which is not
always the right one).