### PR TITLE
Fix bug when passing parameters

### DIFF
--- a/arch/zx48k/translator.py
+++ b/arch/zx48k/translator.py
@@ -223,9 +223,10 @@ class Translator(TranslatorVisitor):
                 self.ic_load(TYPE.uinteger, t, '#' + node.mangled)
             elif scope == SCOPE.parameter:  # A function has used a parameter as an argument to another function call
                 if not node.value.byref:  # It's like a local variable
-                    self.ic_paddr(node.value.offset, t)
+                    offset = 1 if node.type_ in (Type.byte_, Type.ubyte) else 0
+                    self.ic_paddr(node.value.offset + offset, t)
                 else:
-                    self.ic_pload(TYPE.uinteger, t, str(node.value.offset))
+                    self.ic_pload(gl.PTR_TYPE, t, str(node.value.offset))
             elif scope == SCOPE.local:
                 self.ic_paddr(-node.value.offset, t)
 

--- a/tests/functional/byrefbyref.asm
+++ b/tests/functional/byrefbyref.asm
@@ -1,0 +1,73 @@
+	org 32768
+__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (__CALL_BACK__), hl
+	ei
+	jp __MAIN_PROGRAM__
+ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_END - ZXBASIC_USER_DATA
+	.__LABEL__.ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_LEN
+	.__LABEL__.ZXBASIC_USER_DATA EQU ZXBASIC_USER_DATA
+_v:
+	DEFB 00
+ZXBASIC_USER_DATA_END:
+__MAIN_PROGRAM__:
+	ld hl, _v
+	push hl
+	call _primero
+	ld hl, 0
+	ld b, h
+	ld c, l
+__END_PROGRAM:
+	di
+	ld hl, (__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+__CALL_BACK__:
+	DEFW 0
+_primero:
+	push ix
+	ld ix, 0
+	add ix, sp
+	ld l, (ix+4)
+	ld h, (ix+5)
+	push hl
+	call _segundo
+_primero__leave:
+	ld sp, ix
+	pop ix
+	exx
+	pop hl
+	ex (sp), hl
+	exx
+	ret
+_segundo:
+	push ix
+	ld ix, 0
+	add ix, sp
+	ld h, (ix+5)
+	ld l, (ix+4)
+	ld (hl), 2
+_segundo__leave:
+	ld sp, ix
+	pop ix
+	exx
+	pop hl
+	ex (sp), hl
+	exx
+	ret
+	END

--- a/tests/functional/byrefbyref.bas
+++ b/tests/functional/byrefbyref.bas
@@ -1,0 +1,13 @@
+
+dim v as Ubyte
+primero v
+
+sub primero(byref vv as ubyte)
+   segundo vv
+end sub
+
+sub segundo(byref vvv as ubyte)
+   vvv = 2
+end sub
+
+

--- a/tests/functional/byvalbyref.asm
+++ b/tests/functional/byvalbyref.asm
@@ -1,0 +1,75 @@
+	org 32768
+__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (__CALL_BACK__), hl
+	ei
+	jp __MAIN_PROGRAM__
+ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_END - ZXBASIC_USER_DATA
+	.__LABEL__.ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_LEN
+	.__LABEL__.ZXBASIC_USER_DATA EQU ZXBASIC_USER_DATA
+_v:
+	DEFB 00
+ZXBASIC_USER_DATA_END:
+__MAIN_PROGRAM__:
+	ld a, (_v)
+	push af
+	call _primero
+	ld hl, 0
+	ld b, h
+	ld c, l
+__END_PROGRAM:
+	di
+	ld hl, (__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+__CALL_BACK__:
+	DEFW 0
+_primero:
+	push ix
+	ld ix, 0
+	add ix, sp
+	push ix
+	pop hl
+	ld de, 5
+	add hl, de
+	push hl
+	call _segundo
+_primero__leave:
+	ld sp, ix
+	pop ix
+	exx
+	pop hl
+	ex (sp), hl
+	exx
+	ret
+_segundo:
+	push ix
+	ld ix, 0
+	add ix, sp
+	ld h, (ix+5)
+	ld l, (ix+4)
+	ld (hl), 2
+_segundo__leave:
+	ld sp, ix
+	pop ix
+	exx
+	pop hl
+	ex (sp), hl
+	exx
+	ret
+	END

--- a/tests/functional/byvalbyref.bas
+++ b/tests/functional/byvalbyref.bas
@@ -1,0 +1,13 @@
+
+dim v as Ubyte
+primero v
+
+sub primero(vv as ubyte)
+   segundo vv
+end sub
+
+sub segundo(byref vvv as ubyte)
+   vvv = 2
+end sub
+
+

--- a/tests/functional/localbyref.asm
+++ b/tests/functional/localbyref.asm
@@ -1,0 +1,80 @@
+	org 32768
+__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (__CALL_BACK__), hl
+	ei
+	jp __MAIN_PROGRAM__
+ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_END - ZXBASIC_USER_DATA
+	.__LABEL__.ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_LEN
+	.__LABEL__.ZXBASIC_USER_DATA EQU ZXBASIC_USER_DATA
+ZXBASIC_USER_DATA_END:
+__MAIN_PROGRAM__:
+	call _primero
+	ld hl, 0
+	ld b, h
+	ld c, l
+__END_PROGRAM:
+	di
+	ld hl, (__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+__CALL_BACK__:
+	DEFW 0
+_primero:
+	push ix
+	ld ix, 0
+	add ix, sp
+	ld hl, 0
+	push hl
+	inc sp
+	push ix
+	pop hl
+	ld bc, -1
+	add hl, bc
+	ex de, hl
+	ld hl, __LABEL0
+	ld bc, 1
+	ldir
+	push ix
+	pop hl
+	ld de, -1
+	add hl, de
+	push hl
+	call _segundo
+_primero__leave:
+	ld sp, ix
+	pop ix
+	ret
+_segundo:
+	push ix
+	ld ix, 0
+	add ix, sp
+	ld h, (ix+5)
+	ld l, (ix+4)
+	ld (hl), 2
+_segundo__leave:
+	ld sp, ix
+	pop ix
+	exx
+	pop hl
+	ex (sp), hl
+	exx
+	ret
+__LABEL0:
+	DEFB 01h
+	END

--- a/tests/functional/localbyref.bas
+++ b/tests/functional/localbyref.bas
@@ -1,0 +1,13 @@
+
+primero()
+
+sub primero()
+   DIM vv as Ubyte = 1
+   segundo vv
+end sub
+
+sub segundo(byref vvv as ubyte)
+   vvv = 2
+end sub
+
+


### PR DESCRIPTION
Parameters of type Byte / Ubyte has an odd alignment.
When passing the address of such parameters in a function
call as a ByRef, the offset must be increased by one.