### PR TITLE
Make input to sound like original zx48 key taps

### DIFF
--- a/src/arch/zx48k/library/input.bas
+++ b/src/arch/zx48k/library/input.bas
@@ -50,7 +50,7 @@ FUNCTION input(MaxLen AS UINTEGER) AS STRING
             BEEPER EQU 0x3B5
 
             ld a, (PIP)
-            or a
+            cp 0xFF
             jr z, NO_CLICK
             push ix
             ld e, a

--- a/src/arch/zxnext/library/input.bas
+++ b/src/arch/zxnext/library/input.bas
@@ -50,7 +50,7 @@ FUNCTION input(MaxLen AS UINTEGER) AS STRING
             BEEPER EQU 0x3B5
 
             ld a, (PIP)
-            or a
+            cp 0xFF
             jr z, NO_CLICK
             push ix
             ld e, a


### PR DESCRIPTION
Use POKE 23609, -1 (or 255) to mute it.