### PR TITLE
Fix warning on declare functions

### DIFF
--- a/src/api/symboltable.py
+++ b/src/api/symboltable.py
@@ -330,15 +330,16 @@ class SymbolTable:
 
         return offset
 
-    def leave_scope(self):
+    def leave_scope(self, show_warnings=True):
         """ Ends a function body and pops current scope out of the symbol table.
         """
         for v in self.table[self.current_scope].values(filter_by_opt=False):
             if not v.accessed:
                 if v.scope == SCOPE.parameter:
                     kind = 'Parameter'
-                    v.accessed = True  # HINT: Parameters must always be present even if not used!
-                    if not v.byref:  # HINT: byref is always marked as used: it can be used to return a value
+                    v.accessed = True  # Parameters must always be present even if not used!
+                    # byref is always marked as used: it can be used to return a value
+                    if show_warnings and not v.byref:
                         warning_not_used(v.lineno, v.name, kind=kind)
 
         for entry in self.table[self.current_scope].values(filter_by_opt=True):  # Symbols of the current level

--- a/src/zxbc/zxbparser.py
+++ b/src/zxbc/zxbparser.py
@@ -2904,7 +2904,7 @@ def p_funcdeclforward(p):
         error(p.lineno(1), "duplicated declaration for function '%s'" % p[2].name)
 
     p[2].entry.forwarded = True
-    SYMBOL_TABLE.leave_scope()
+    SYMBOL_TABLE.leave_scope(show_warnings=False)
     FUNCTION_LEVEL.pop()
 
 

--- a/tests/functional/test_errmsg.txt
+++ b/tests/functional/test_errmsg.txt
@@ -29,7 +29,6 @@ builtin.bi:5: warning: [W520] missing whitespace after macro name
 builtin.bi:16: warning: [W500] builtin macro "__FILE__" redefined
 builtin.bi:17: warning: [W500] builtin macro "__LINE__" redefined
 >>> process_file('param3.bas')
-param3.bas:3: warning: Parameter 's' is never used
 param3.bas:5: error: Function 'test' (previously declared at 3) type mismatch
 param3.bas:6: error: Type Error: Function must return a numeric value, not a string
 >>> process_file('typecast1.bas')


### PR DESCRIPTION
When using DECLARE in a functions with parameters
a warning about unused parameters was issued. Fixed.