### PR TITLE
Fix crash on unknown pragma

### DIFF
--- a/src/api/errmsg.py
+++ b/src/api/errmsg.py
@@ -192,6 +192,11 @@ def warning_function_should_return_a_value(lineno: int, func_name: str, fname: O
 def warning_value_will_be_truncated(lineno: int, fname: Optional[str] = None):
     warning(lineno, "Value will be truncated", fname=fname)
 
+
+@register_warning('300')
+def warning_ignoring_unknown_pragma(lineno: int, pragma_name: str):
+    warning(lineno, f"Ignoring unknown pragma '{pragma_name}'")
+
 # endregion
 
 # region [Syntax Errors]

--- a/src/zxbc/zxbparser.py
+++ b/src/zxbc/zxbparser.py
@@ -47,6 +47,7 @@ import src.api.errmsg
 import src.api.symboltable
 import src.api.config
 import src.api.utils
+import src.api.options
 
 # Symbol Classes
 from src import symbols, arch
@@ -3190,19 +3191,28 @@ def p_preproc_line_pragma_option(p):
                      | _PRAGMA ID EQ STRING
                      | _PRAGMA ID EQ INTEGER
     """
-    setattr(OPTIONS, p[2], p[4])
+    try:
+        setattr(OPTIONS, p[2], p[4])
+    except src.api.options.UndefinedOptionError:
+        src.api.errmsg.warning_ignoring_unknown_pragma(p.lineno(2), p[2])
 
 
 def p_preproc_pragma_push(p):
     """ preproc_line : _PRAGMA _PUSH LP ID RP
     """
-    OPTIONS[p[4]].push()
+    try:
+        OPTIONS[p[4]].push()
+    except src.api.options.UndefinedOptionError:
+        src.api.errmsg.warning_ignoring_unknown_pragma(p.lineno(4), p[4])
 
 
 def p_preproc_pragma_pop(p):
     """ preproc_line : _PRAGMA _POP LP ID RP
     """
-    OPTIONS[p[4]].pop()
+    try:
+        OPTIONS[p[4]].pop()
+    except src.api.options.UndefinedOptionError:
+        src.api.errmsg.warning_ignoring_unknown_pragma(p.lineno(4), p[4])
 
 
 # region INTERNAL FUNCTIONS

--- a/tests/functional/bad_pragma.asm
+++ b/tests/functional/bad_pragma.asm
@@ -1,0 +1,38 @@
+	org 32768
+__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (__CALL_BACK__), hl
+	ei
+	jp __MAIN_PROGRAM__
+__CALL_BACK__:
+	DEFW 0
+ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_END - ZXBASIC_USER_DATA
+	.__LABEL__.ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_LEN
+	.__LABEL__.ZXBASIC_USER_DATA EQU ZXBASIC_USER_DATA
+ZXBASIC_USER_DATA_END:
+__MAIN_PROGRAM__:
+	ld hl, 0
+	ld b, h
+	ld c, l
+__END_PROGRAM:
+	di
+	ld hl, (__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+	;; --- end of user code ---
+	END

--- a/tests/functional/bad_pragma.bas
+++ b/tests/functional/bad_pragma.bas
@@ -1,0 +1,8 @@
+
+#pragma BAD_PRAGMA = 1
+
+#pragma PUSH(BAD_PRAGMA)
+
+#pragma POP(BAD_PRAGMA)
+
+

--- a/tests/functional/test_errmsg.txt
+++ b/tests/functional/test_errmsg.txt
@@ -196,6 +196,10 @@ opt2_unused_var1.bas:2: warning: Variable 'a' is never used
 >>> process_file('dim_at_init_err.bas')
 dim_at_init_err.bas:3: error: Syntax Error. Unexpected token 'AT' <AT>
 dim_at_init_err.bas:4: error: Syntax Error. Unexpected token 'AT' <AT>
+>>> process_file('bad_pragma.bas')
+bad_pragma.bas:2: warning: Ignoring unknown pragma 'BAD_PRAGMA'
+bad_pragma.bas:4: warning: Ignoring unknown pragma 'BAD_PRAGMA'
+bad_pragma.bas:6: warning: Ignoring unknown pragma 'BAD_PRAGMA'
 
 # Test warning silencing
 >>> process_file('mcleod3.bas', ['-S', '-q', '-O --expect-warnings=2'])


### PR DESCRIPTION
Unknown pragmas are ignored and a warning is emitted instead.