### PR TITLE
Do not add redundant END

### DIFF
--- a/src/zxbc/zxbparser.py
+++ b/src/zxbc/zxbparser.py
@@ -37,6 +37,7 @@ from src.api.check import is_numeric
 from src.api.check import is_unsigned
 from src.api.check import is_static
 from src.api.check import is_string
+from src.api.check import is_ender
 
 from src.api.constants import CLASS
 from src.api.constants import SCOPE
@@ -530,7 +531,8 @@ def p_start(p):
     __end = make_sentence(p.lexer.lineno, 'END', make_number(0, lineno=p.lexer.lineno), sentinel=True)
 
     if not is_null(ast):
-        ast.appendChild(__end)
+        if isinstance(ast, symbols.BLOCK) and not is_ender(ast[-1]):
+            ast.appendChild(__end)
     else:
         ast = __end
 

--- a/tests/functional/doloop4.asm
+++ b/tests/functional/doloop4.asm
@@ -26,16 +26,5 @@ __LABEL__20:
 	jp __LABEL0
 __LABEL1:
 	jp __LABEL__20
-__END_PROGRAM:
-	di
-	ld hl, (__CALL_BACK__)
-	ld sp, hl
-	exx
-	pop hl
-	exx
-	pop iy
-	pop ix
-	ei
-	ret
 	;; --- end of user code ---
 	END

--- a/tests/functional/end.asm
+++ b/tests/functional/end.asm
@@ -34,9 +34,5 @@ __END_PROGRAM:
 	pop ix
 	ei
 	ret
-	ld hl, 0
-	ld b, h
-	ld c, l
-	jp __END_PROGRAM
 	;; --- end of user code ---
 	END

--- a/tests/functional/fornextopt.asm
+++ b/tests/functional/fornextopt.asm
@@ -39,16 +39,5 @@ __LABEL0:
 	jp nc, __LABEL3
 __LABEL2:
 	jp __LABEL__lbl
-__END_PROGRAM:
-	di
-	ld hl, (__CALL_BACK__)
-	ld sp, hl
-	exx
-	pop hl
-	exx
-	pop iy
-	pop ix
-	ei
-	ret
 	;; --- end of user code ---
 	END

--- a/tests/functional/fornextopt2.asm
+++ b/tests/functional/fornextopt2.asm
@@ -38,16 +38,5 @@ __LABEL0:
 	jp nc, __LABEL3
 __LABEL2:
 	jp __LABEL__lbl
-__END_PROGRAM:
-	di
-	ld hl, (__CALL_BACK__)
-	ld sp, hl
-	exx
-	pop hl
-	exx
-	pop iy
-	pop ix
-	ei
-	ret
 	;; --- end of user code ---
 	END

--- a/tests/functional/ifemptylabel1.asm
+++ b/tests/functional/ifemptylabel1.asm
@@ -28,16 +28,5 @@ __LABEL__Here:
 	inc (hl)
 __LABEL1:
 	jp __LABEL__Here
-__END_PROGRAM:
-	di
-	ld hl, (__CALL_BACK__)
-	ld sp, hl
-	exx
-	pop hl
-	exx
-	pop iy
-	pop ix
-	ei
-	ret
 	;; --- end of user code ---
 	END

--- a/tests/functional/ifemptylabel2.asm
+++ b/tests/functional/ifemptylabel2.asm
@@ -32,16 +32,5 @@ __LABEL__Here:
 	ld (_a), a
 __LABEL1:
 	jp __LABEL__Here
-__END_PROGRAM:
-	di
-	ld hl, (__CALL_BACK__)
-	ld sp, hl
-	exx
-	pop hl
-	exx
-	pop iy
-	pop ix
-	ei
-	ret
 	;; --- end of user code ---
 	END

--- a/tests/functional/ongosub.asm
+++ b/tests/functional/ongosub.asm
@@ -79,10 +79,6 @@ __LABEL__70:
 	call __PRINTSTR
 	call PRINT_EOL
 	ret
-	ld hl, 0
-	ld b, h
-	ld c, l
-	jp __END_PROGRAM
 __LABEL2:
 	DEFW 0003h
 	DEFB 45h
@@ -144,7 +140,7 @@ __ON_GOTO_START:
 	    ld h, (hl)
 	    ld l, a
 	    jp (hl)
-#line 89 "ongosub.bas"
+#line 85 "ongosub.bas"
 #line 1 "/zxbasic/src/arch/zx48k/library-asm/print.asm"
 ; vim:ts=4:sw=4:et:
 ; vim:ts=4:sw=4:et:
@@ -1078,7 +1074,7 @@ __PRINT_TABLE:    ; Jump table for 0 .. 22 codes
 	        DW __PRINT_AT     ; 22 AT
 	        DW __PRINT_TAB    ; 23 TAB
 	        ENDP
-#line 90 "ongosub.bas"
+#line 86 "ongosub.bas"
 #line 1 "/zxbasic/src/arch/zx48k/library-asm/printstr.asm"
 #line 1 "/zxbasic/src/arch/zx48k/library-asm/free.asm"
 ; vim: ts=4:et:sw=4:
@@ -1383,5 +1379,5 @@ __PRINT_STR:
 	        ld d, a ; Saves a FLAG
 	        jp __PRINT_STR_LOOP
 			ENDP
-#line 91 "ongosub.bas"
+#line 87 "ongosub.bas"
 	END

--- a/tests/functional/opt1_endtest.asm
+++ b/tests/functional/opt1_endtest.asm
@@ -37,9 +37,5 @@ __END_PROGRAM:
 	pop ix
 	ei
 	ret
-	ld hl, 0
-	ld b, h
-	ld c, l
-	jp __END_PROGRAM
 	;; --- end of user code ---
 	END

--- a/tests/functional/test_errmsg.txt
+++ b/tests/functional/test_errmsg.txt
@@ -107,10 +107,8 @@ ifempty0.bas:3: warning: Useless empty IF ignored
 forempty.bas:4: warning: STEP value is 0 and FOR might loop forever
 >>> process_file('fornextopt.bas')
 fornextopt.bas:4: warning: FOR start value is greater than end. This FOR loop is useless
-fornextopt.bas:10: warning: Unreachable code
 >>> process_file('fornextopt2.bas')
 fornextopt2.bas:4: warning: FOR start value is lower than end. This FOR loop is useless
-fornextopt2.bas:10: warning: Unreachable code
 >>> process_file('atoloduplbl.asm')
 atoloduplbl.asm:3: error: label '.SetSubScreen' already defined at line 2
 >>> process_file('asmerror2.asm')
@@ -202,6 +200,7 @@ bad_pragma.bas:4: warning: Ignoring unknown pragma 'BAD_PRAGMA'
 bad_pragma.bas:6: warning: Ignoring unknown pragma 'BAD_PRAGMA'
 >>> process_file('opt2_global_array2.bas')
 opt2_global_array2.bas:1: warning: Variable 'myArray' is never used
+>>> process_file('end.bas')
 
 # Test warning silencing
 >>> process_file('mcleod3.bas', ['-S', '-q', '-O --expect-warnings=2'])

--- a/tests/functional/whilefalse1.asm
+++ b/tests/functional/whilefalse1.asm
@@ -30,16 +30,5 @@ __LABEL__BAD:
 	jp __LABEL0
 __LABEL1:
 	jp __LABEL__BAD
-__END_PROGRAM:
-	di
-	ld hl, (__CALL_BACK__)
-	ld sp, hl
-	exx
-	pop hl
-	exx
-	pop iy
-	pop ix
-	ei
-	ret
 	;; --- end of user code ---
 	END


### PR DESCRIPTION
If the last instruction in BASIC is an ender (END, STOP, GOTO,
RETURN) do not add an extra END. It's useless.

Fix for #511 