### PR TITLE
Refactorize config constants

### DIFF
--- a/src/api/config.py
+++ b/src/api/config.py
@@ -9,68 +9,203 @@
 #                    the GNU General License
 # ----------------------------------------------------------------------
 
+import os
 import sys
+import configparser
+
+from src import api
 
 # The options container
 from . import options
 from . import global_
 from .options import ANYTYPE
 
+
 # ------------------------------------------------------
 # Common setup and configuration for all tools
 # ------------------------------------------------------
+class OPTION:
+    OUTPUT_FILENAME = 'output_filename'
+    INPUT_FILENAME = 'input_filename'
+    STDERR_FILENAME = 'stderr_filename'
+    DEBUG = 'debug_level'
+
+    # File IO
+    STDIN = 'stdin'
+    STDOUT = 'stdout'
+    STDERR = 'stderr'
+
+    O_LEVEL = 'optimization_level'
+    CASE_INS = 'case_insensitive'
+    ARRAY_BASE = 'array_base'
+    STR_BASE = 'string_base'
+    DEFAULT_BYREF = 'default_byref'
+    MAX_SYN_ERRORS = 'max_syntax_errors'
+
+    MEMORY_MAP = 'memory_map'
+
+    USE_BASIC_LOADER = 'use_basic_loader'
+    AUTORUN = 'autorun'
+    OUTPUT_FILE_TYPE = 'output_file_type'
+    INCLUDE_PATH = 'include_path'
+
+    CHECK_MEMORY = 'memory_check'
+    CHECK_ARRAYS = 'array_check'
+
+    STRICT_BOOL = 'strict_bool'
+
+    ENABLE_BREAK = 'enable_break'
+    EMIT_BACKEND = 'emit_backend'
+
+    EXPLICIT = 'explicit'
+    STRICT = 'strict'
+
+    ARCH = 'architecture'
+    EXPECTED_WARNINGS = 'expected_warnings'
+    HIDE_WARNING_CODES = 'hide_warning_codes'
+
+    # ASM Options
+    ASM_ZXNEXT = 'zxnext'
+    FORCE_ASM_BRACKET = 'force_asm_brackets'
+
 
 OPTIONS = options.Options()
 
 
+def load_config_from_file(filename: str, section: str, options_: options.Options = None, stop_on_error=True) -> bool:
+    """ Opens file and read options from the given section. If stop_on_error is set,
+    the program stop. Otherwise the result of the operation will be
+    returned (True on success, False on failure)
+    """
+    if options_ is None:
+        options_ = OPTIONS
+
+    try:
+        cfg = configparser.ConfigParser()
+        cfg.read(filename, encoding='utf-8')
+    except (configparser.DuplicateSectionError, configparser.DuplicateOptionError):
+        api.errmsg.msg_output(f"Invalid config file '{filename}': it has duplicated fields")
+        if stop_on_error:
+            sys.exit(1)
+        return False
+    except FileNotFoundError:
+        api.errmsg.msg_output(f"Config file '{filename}' not found")
+        if stop_on_error:
+            sys.exit(1)
+        return False
+
+    if section not in cfg.sections():
+        api.errmsg.msg_output(f"Section '{section}' not found in config file '{filename}'")
+        if stop_on_error:
+            sys.exit(1)
+        return False
+
+    parsing = {
+        int: cfg.getint,
+        float: cfg.getfloat,
+        bool: cfg.getboolean
+    }
+
+    for opt in cfg.options(section):
+        options_[opt].value = parsing.get(options_[opt].type, cfg.get)(option=opt)
+
+    return True
+
+
+def save_config_into_file(filename: str, section: str, options_: options.Options = None, stop_on_error=True) -> bool:
+    """ Save config into config ini file into the given section. If stop_on_error is set,
+    the program stop. Otherwise the result of the operation will be
+    returned (True on success, False on failure)
+    """
+    if options_ is None:
+        options_ = OPTIONS
+
+    cfg = configparser.ConfigParser()
+    if os.path.exists(filename):
+        try:
+            cfg.read(filename, encoding='utf-8')
+        except (configparser.DuplicateSectionError, configparser.DuplicateOptionError):
+            api.errmsg.msg_output(f"Invalid config file '{filename}': it has duplicated fields")
+            if stop_on_error:
+                sys.exit(1)
+            return False
+
+    cfg[section] = {}
+    for opt_name, opt in options.Options.get_options(options_):
+        if opt_name.startswith('__') or opt.value is None or opt_name in ('stderr', 'stdin', 'stdout'):
+            continue
+
+        if opt.type == bool:
+            cfg[section][opt_name] = str(opt.value).lower()
+            continue
+
+        cfg[section][opt_name] = str(opt.value)
+
+    try:
+        with open(filename, 'wt', encoding='utf-8') as f:
+            cfg.write(f)
+    except IOError:
+        api.errmsg.msg_output(f"Can't write config file '{filename}'")
+        if stop_on_error:
+            sys.exit(1)
+        return False
+
+    return True
+
+
 def init():
+    """
+    Default Options and Compilation Flags
+
+    optimization -- Optimization level. Use -O flag to change.
+    case_insensitive -- Whether user identifiers are case insensitive
+                             or not
+    array_base -- Default array lower bound
+    param_byref --Default parameter passing. TRUE => By Reference
+    """
+
     OPTIONS.reset()
-    OPTIONS.add_option('outputFileName', str)
-    OPTIONS.add_option('inputFileName', str)
-    OPTIONS.add_option('StdErrFileName', str)
-    OPTIONS.add_option('Debug', int, 0)
+
+    OPTIONS.add_option(OPTION.OUTPUT_FILENAME, str)
+    OPTIONS.add_option(OPTION.INPUT_FILENAME, str)
+    OPTIONS.add_option(OPTION.STDERR_FILENAME, str)
+    OPTIONS.add_option(OPTION.DEBUG, int, 0)
 
     # Default console redirections
-    OPTIONS.add_option('stdin', ANYTYPE, sys.stdin)
-    OPTIONS.add_option('stdout', ANYTYPE, sys.stdout)
-    OPTIONS.add_option('stderr', ANYTYPE, sys.stderr)
+    OPTIONS.add_option(OPTION.STDIN, ANYTYPE, sys.stdin)
+    OPTIONS.add_option(OPTION.STDOUT, ANYTYPE, sys.stdout)
+    OPTIONS.add_option(OPTION.STDERR, ANYTYPE, sys.stderr)
 
-    # ----------------------------------------------------------------------
-    # Default Options and Compilation Flags
-    #
-    # optimization -- Optimization level. Use -O flag to change.
-    # case_insensitive -- Whether user identifiers are case insensitive
-    #                          or not
-    # array_base -- Default array lower bound
-    # param_byref --Default parameter passing. TRUE => By Reference
-    # ----------------------------------------------------------------------
-    OPTIONS.add_option('optimization', int, global_.DEFAULT_OPTIMIZATION_LEVEL)
-    OPTIONS.add_option('case_insensitive', bool, False)
-    OPTIONS.add_option('array_base', int, 0)
-    OPTIONS.add_option('byref', bool, False)
-    OPTIONS.add_option('max_syntax_errors', int, global_.DEFAULT_MAX_SYNTAX_ERRORS)
-    OPTIONS.add_option('string_base', int, 0)
-    OPTIONS.add_option('memory_map', str, None)
-    OPTIONS.add_option('bracket', bool, False)
+    OPTIONS.add_option(OPTION.O_LEVEL, int, global_.DEFAULT_OPTIMIZATION_LEVEL)
+    OPTIONS.add_option(OPTION.CASE_INS, bool, False)
+    OPTIONS.add_option(OPTION.ARRAY_BASE, int, 0)
+    OPTIONS.add_option(OPTION.DEFAULT_BYREF, bool, False)
+    OPTIONS.add_option(OPTION.MAX_SYN_ERRORS, int, global_.DEFAULT_MAX_SYNTAX_ERRORS)
+    OPTIONS.add_option(OPTION.STR_BASE, int, 0)
+    OPTIONS.add_option(OPTION.MEMORY_MAP, str, None)
+    OPTIONS.add_option(OPTION.FORCE_ASM_BRACKET, bool, False)
 
-    OPTIONS.add_option('use_loader', bool, False)  # Whether to use a loader
-    OPTIONS.add_option('autorun', bool, False)  # Whether to add autostart code (needs basic loader = true)
-    OPTIONS.add_option('output_file_type', str, 'bin')  # bin, tap, tzx etc...
-    OPTIONS.add_option('include_path', str, '')  # Include path, like '/var/lib:/var/include'
+    OPTIONS.add_option(OPTION.USE_BASIC_LOADER, bool, False)  # Whether to use a loader
+    OPTIONS.add_option(OPTION.AUTORUN, bool, False)  # Whether to add autostart code (needs basic loader = true)
+    OPTIONS.add_option(OPTION.OUTPUT_FILE_TYPE, str, 'bin')  # bin, tap, tzx etc...
+    OPTIONS.add_option(OPTION.INCLUDE_PATH, str, '')  # Include path, like '/var/lib:/var/include'
 
-    OPTIONS.add_option('memoryCheck', bool, False)
-    OPTIONS.add_option('strictBool', bool, False)
-    OPTIONS.add_option('arrayCheck', bool, False)
-    OPTIONS.add_option('enableBreak', bool, False)
-    OPTIONS.add_option('emitBackend', bool, False)
+    OPTIONS.add_option(OPTION.CHECK_MEMORY, bool, False)
+    OPTIONS.add_option(OPTION.STRICT_BOOL, bool, False)
+    OPTIONS.add_option(OPTION.CHECK_ARRAYS, bool, False)
+
+    OPTIONS.add_option(OPTION.ENABLE_BREAK, bool, False)
+    OPTIONS.add_option(OPTION.EMIT_BACKEND, bool, False)
     OPTIONS.add_option('__DEFINES', dict, {})
-    OPTIONS.add_option('explicit', bool, False)
+    OPTIONS.add_option(OPTION.EXPLICIT, bool, False)
     OPTIONS.add_option('Sinclair', bool, False)
-    OPTIONS.add_option('strict', bool, False)  # True to force type checking
-    OPTIONS.add_option('zxnext', bool, False)  # True to enable ZX Next ASM opcodes
-    OPTIONS.add_option('architecture', str, None)  # Architecture
-    OPTIONS.add_option('expect_warnings', int, 0)  # Expected Warnings that will be silenced
-    OPTIONS.add_option('hide_warning_codes', bool, False)  # Whether to show WXXX warning codes or not
+    OPTIONS.add_option(OPTION.STRICT, bool, False)  # True to force type checking
+    OPTIONS.add_option(OPTION.ASM_ZXNEXT, bool, False)  # True to enable ZX Next ASM opcodes
+    OPTIONS.add_option(OPTION.ARCH, str, None)  # Architecture
+    OPTIONS.add_option(OPTION.EXPECTED_WARNINGS, int, 0)  # Expected Warnings that will be silenced
+    OPTIONS.add_option(OPTION.HIDE_WARNING_CODES, bool, False)  # Whether to show WXXX warning codes or not
+
+    save_config_into_file('project.ini', 'zxbc', stop_on_error=True)
 
 
 init()

--- a/src/api/debug.py
+++ b/src/api/debug.py
@@ -15,7 +15,7 @@ __all__ = ['__DEBUG__', '__LINE__', '__FILE__']
 
 
 def __DEBUG__(msg, level=1):
-    if level > OPTIONS.Debug:
+    if level > OPTIONS.debug_level:
         return
 
     line = inspect.getouterframes(inspect.currentframe())[1][2]

--- a/src/api/errmsg.py
+++ b/src/api/errmsg.py
@@ -42,7 +42,7 @@ def msg_output(msg: str) -> None:
 
 
 def info(msg: str) -> None:
-    if OPTIONS.Debug < 1:
+    if OPTIONS.debug_level < 1:
         return
     OPTIONS.stderr.write("info: %s\n" % msg)
 
@@ -69,7 +69,7 @@ def warning(lineno: int, msg: str, fname: Optional[str] = None) -> None:
     """ Generic warning error routine
     """
     global_.has_warnings += 1
-    if global_.has_warnings <= OPTIONS.expect_warnings:
+    if global_.has_warnings <= OPTIONS.expected_warnings:
         return
 
     if fname is None:
@@ -162,7 +162,7 @@ def warning_empty_if(lineno: int):
 def warning_not_used(lineno: int, id_: str, kind: str = 'Variable', fname: Optional[str] = None):
     """ Emits an optimization warning
     """
-    if OPTIONS.optimization > 0:
+    if OPTIONS.optimization_level > 0:
         warning(lineno, "%s '%s' is never used" % (kind, id_), fname=fname)
 
 

--- a/src/api/optimize.py
+++ b/src/api/optimize.py
@@ -34,7 +34,7 @@ class ToVisit(NamedTuple):
 class GenericVisitor(NodeVisitor):
     @property
     def O_LEVEL(self):
-        return OPTIONS.optimization
+        return OPTIONS.optimization_level
 
     NOP = symbols.NOP()  # Return this for "erased" nodes
 

--- a/src/api/options.py
+++ b/src/api/options.py
@@ -14,6 +14,7 @@ import json
 from typing import Dict
 from typing import List
 from typing import Any
+from typing import Tuple
 
 from .errors import Error
 
@@ -205,3 +206,9 @@ class Options:
 
     def __contains__(self, item: str):
         return item in self._options
+
+    @classmethod
+    def get_options(cls, instance: 'Options') -> List[Tuple[str, Option]]:
+        """ Iterate over all options of the given instance
+        """
+        return list(instance._options.items())

--- a/src/api/symboltable.py
+++ b/src/api/symboltable.py
@@ -87,17 +87,17 @@ class Scope:
         self.caseins.pop(key, None)
 
     def values(self, filter_by_opt=True):
-        if filter_by_opt and OPTIONS.optimization > 1:
+        if filter_by_opt and OPTIONS.optimization_level > 1:
             return [y for x, y in self.symbols.items() if y.accessed]
         return [y for x, y in self.symbols.items()]
 
     def keys(self, filter_by_opt=True):
-        if filter_by_opt and OPTIONS.optimization > 1:
+        if filter_by_opt and OPTIONS.optimization_level > 1:
             return [x for x, y in self.symbols.items() if y.accessed]
         return self.symbols.keys()
 
     def items(self, filter_by_opt=True):
-        if filter_by_opt and OPTIONS.optimization > 1:
+        if filter_by_opt and OPTIONS.optimization_level > 1:
             return [(x, y) for x, y in self.symbols.items() if y.accessed]
         return self.symbols.items()
 

--- a/src/arch/zx48k/backend/__init__.py
+++ b/src/arch/zx48k/backend/__init__.py
@@ -2268,7 +2268,7 @@ def convertToBool():
     """ Convert a byte value to boolean (0 or 1) if
     the global flag strictBool is True
     """
-    if not OPTIONS.strictBool:
+    if not OPTIONS.strict_bool:
         return []
 
     return [
@@ -2347,7 +2347,7 @@ def emit(mem: List[Quad], optimize=True):
     'output' array
     """
     # Optimization patterns: at this point no more than -O2
-    patterns = [x for x in engine.PATTERNS if x.level <= min(OPTIONS.optimization, 2)]
+    patterns = [x for x in engine.PATTERNS if x.level <= min(OPTIONS.optimization_level, 2)]
 
     def output_join(output: List[str], new_chunk: List[str], optimize: bool = True):
         """ Extends output instruction list
@@ -2373,7 +2373,7 @@ def emit(mem: List[Quad], optimize=True):
         if RE_BOOL.match(i.quad[0]):  # If it is a boolean operation convert it to 0/1 if the STRICT_BOOL flag is True
             output_join(output, convertToBool(), optimize=optimize)
 
-    if optimize and OPTIONS.optimization > 1:
+    if optimize and OPTIONS.optimization_level > 1:
         remove_unused_labels(output)
         tmp = output
         output = []

--- a/src/arch/zx48k/optimizer/__init__.py
+++ b/src/arch/zx48k/optimizer/__init__.py
@@ -183,10 +183,10 @@ def optimize(initial_memory):
     PROC_COUNTER = 0
 
     cleanupmem(initial_memory)
-    if OPTIONS.optimization <= 2:  # if -O2 or lower, do nothing and return
+    if OPTIONS.optimization_level <= 2:  # if -O2 or lower, do nothing and return
         return '\n'.join(x for x in initial_memory if not RE_PRAGMA.match(x))
 
-    basicblock.BasicBlock.clean_asm_args = OPTIONS.optimization > 3
+    basicblock.BasicBlock.clean_asm_args = OPTIONS.optimization_level > 3
     bb = basicblock.BasicBlock(initial_memory)
     cleanup_local_labels(bb)
     initialize_memory(bb)
@@ -235,7 +235,7 @@ def optimize(initial_memory):
     for x in basic_blocks:
         x.compute_cpu_state()
 
-    filtered_patterns_list = [p for p in engine.PATTERNS if OPTIONS.optimization >= p.level >= 3]
+    filtered_patterns_list = [p for p in engine.PATTERNS if OPTIONS.optimization_level >= p.level >= 3]
     for x in basic_blocks:
         x.optimize(filtered_patterns_list)
 

--- a/src/arch/zx48k/optimizer/basicblock.py
+++ b/src/arch/zx48k/optimizer/basicblock.py
@@ -580,7 +580,7 @@ class BasicBlock(Iterable[MemCell]):
             'z': str(self.cpu.Z) if self.cpu.Z is not None else helpers.new_tmp_val()
         }.get(x.lower(), helpers.new_tmp_val())
 
-        if src.api.config.OPTIONS.optimization > 3:
+        if src.api.config.OPTIONS.optimization_level > 3:
             regs, mems = self.guesses_initial_state_from_origin_blocks()
         else:
             regs, mems = {}, {}

--- a/src/arch/zx48k/translator.py
+++ b/src/arch/zx48k/translator.py
@@ -188,7 +188,7 @@ class Translator(TranslatorVisitor):
         for i in range(len(node) - 1, -1, -1):  # visit in reverse order
             yield node[i]
 
-            if isinstance(node.parent, symbols.ARRAYACCESS) and OPTIONS.arrayCheck and \
+            if isinstance(node.parent, symbols.ARRAYACCESS) and OPTIONS.array_check and \
                     node.parent.entry.scope != SCOPE.parameter:
                 upper = node.parent.entry.bounds[i].upper
                 lower = node.parent.entry.bounds[i].lower

--- a/src/arch/zx48k/translatorvisitor.py
+++ b/src/arch/zx48k/translatorvisitor.py
@@ -83,7 +83,7 @@ class TranslatorVisitor(TranslatorInstVisitor):
 
     @property
     def O_LEVEL(self):
-        return OPTIONS.optimization
+        return OPTIONS.optimization_level
 
     @staticmethod
     def TYPE(type_):

--- a/src/symbols/argument.py
+++ b/src/symbols/argument.py
@@ -28,7 +28,7 @@ class SymbolARGUMENT(Symbol):
         """
         super(SymbolARGUMENT, self).__init__(value)
         self.lineno = lineno
-        self.byref = byref if byref is not None else OPTIONS.byref
+        self.byref = byref if byref is not None else OPTIONS.default_byref
 
     @property
     def t(self):

--- a/src/symbols/paramdecl.py
+++ b/src/symbols/paramdecl.py
@@ -22,7 +22,7 @@ class SymbolPARAMDECL(SymbolVAR):
     """
     def __init__(self, varname, lineno, type_=None):
         super(SymbolPARAMDECL, self).__init__(varname, lineno, type_=type_, class_=CLASS.var)
-        self.byref = OPTIONS.byref  # By default all params By value (false)
+        self.byref = OPTIONS.default_byref  # By default all params By value (false)
         self.offset = None  # Set by PARAMLIST, contains positive offset from top of the stack
         self.scope = SCOPE.parameter
 

--- a/src/zxbasm/asmlex.py
+++ b/src/zxbasm/asmlex.py
@@ -335,13 +335,13 @@ class Lexer(object):
 
     def t_LP(self, t):
         r'\('
-        if t.value != '[' and OPTIONS.bracket:
+        if t.value != '[' and OPTIONS.force_asm_brackets:
             t.type = 'LPP'
         return t
 
     def t_RP(self, t):
         r'\)'
-        if t.value != ']' and OPTIONS.bracket:
+        if t.value != ']' and OPTIONS.force_asm_brackets:
             t.type = 'RPP'
         return t
 

--- a/src/zxbasm/asmparse.py
+++ b/src/zxbasm/asmparse.py
@@ -1559,7 +1559,7 @@ def assemble(input_):
     else:
         parser_ = parser
 
-    parser_.parse(input_, lexer=LEXER, debug=OPTIONS.Debug > 1)
+    parser_.parse(input_, lexer=LEXER, debug=OPTIONS.debug_level > 1)
     if len(MEMORY.scopes):
         error(MEMORY.scopes[-1], 'Missing ENDP to close this scope')
 
@@ -1600,7 +1600,7 @@ def generate_binary(outputfname, format_, progname='', binary_files=None, headle
     if not progname:
         progname = os.path.basename(outputfname)[:10]
 
-    if OPTIONS.use_loader:
+    if OPTIONS.use_basic_loader:
         program = basic.Basic()
         if org > 16383:  # Only for zx48k: CLEAR if above 16383
             program.add_line([['CLEAR', org - 1]])
@@ -1618,7 +1618,7 @@ def generate_binary(outputfname, format_, progname='', binary_files=None, headle
             emitter = outfmt.BinaryEmitter()
 
     loader_bytes = None
-    if OPTIONS.use_loader:
+    if OPTIONS.use_basic_loader:
         loader_bytes = program.bytes
 
     assert isinstance(emitter, outfmt.CodeEmitter)
@@ -1636,13 +1636,13 @@ def main(argv):
     """
     init()
 
-    if OPTIONS.StdErrFileName:
-        OPTIONS.stderr = open('wt', OPTIONS.StdErrFileName)
+    if OPTIONS.stderr_filename:
+        OPTIONS.stderr = open('wt', OPTIONS.stderr_filename)
 
-    asmlex.FILENAME = OPTIONS.inputFileName = argv[0]
-    input_ = open(OPTIONS.inputFileName, 'rt').read()
+    asmlex.FILENAME = OPTIONS.input_filename = argv[0]
+    input_ = open(OPTIONS.input_filename, 'rt').read()
     assemble(input_)
-    generate_binary(OPTIONS.outputFileName, OPTIONS.output_file_type)
+    generate_binary(OPTIONS.output_filename, OPTIONS.output_file_type)
 
 
 # Z80 only ASM parser

--- a/src/zxbasm/zxbasm.py
+++ b/src/zxbasm/zxbasm.py
@@ -34,11 +34,11 @@ def main(args=None):
     # Create option parser
     o_parser = argparse.ArgumentParser()
     o_parser.add_argument('PROGRAM', type=str, help='ASM program file')
-    o_parser.add_argument("-d", "--debug", action="count", default=OPTIONS.Debug,
+    o_parser.add_argument("-d", "--debug", action="count", default=OPTIONS.debug_level,
                           help="Enable verbosity/debugging output")
 
     o_parser.add_argument("-O", "--optimize", type=int, dest="optimization_level",
-                          help="Sets optimization level. 0 = None", default=OPTIONS.optimization)
+                          help="Sets optimization level. 0 = None", default=OPTIONS.optimization_level)
 
     o_parser.add_argument("-o", "--output", type=str, dest="output_file",
                           help="Sets output file. Default is input filename with .bin extension", default=None)
@@ -55,7 +55,7 @@ def main(args=None):
     o_parser.add_argument("-a", "--autorun", action="store_true", default=False,
                           help="Sets the program to auto run once loaded (implies --BASIC)")
 
-    o_parser.add_argument("-e", "--errmsg", type=str, dest="stderr", default=OPTIONS.StdErrFileName,
+    o_parser.add_argument("-e", "--errmsg", type=str, dest="stderr", default=OPTIONS.stderr_filename,
                           help="Error messages file (standard error console by default")
 
     o_parser.add_argument("-M", "--mmap", type=str, dest="memory_map", default=None,
@@ -75,15 +75,15 @@ def main(args=None):
         o_parser.error("No such file or directory: '%s'" % options.PROGRAM)
         sys.exit(2)
 
-    OPTIONS.Debug = int(options.debug)
-    OPTIONS.inputFileName = options.PROGRAM
-    OPTIONS.outputFileName = options.output_file
-    OPTIONS.optimization = options.optimization_level
-    OPTIONS.use_loader = options.autorun or options.basic
+    OPTIONS.debug_level = int(options.debug)
+    OPTIONS.input_filename = options.PROGRAM
+    OPTIONS.output_filename = options.output_file
+    OPTIONS.optimization_level = options.optimization_level
+    OPTIONS.use_basic_loader = options.autorun or options.basic
     OPTIONS.autorun = options.autorun
-    OPTIONS.StdErrFileName = options.stderr
+    OPTIONS.stderr_filename = options.stderr
     OPTIONS.memory_map = options.memory_map
-    OPTIONS.bracket = options.bracket
+    OPTIONS.force_asm_brackets = options.bracket
     OPTIONS.zxnext = options.zxnext
 
     if options.tzx:
@@ -91,18 +91,18 @@ def main(args=None):
     elif options.tap:
         OPTIONS.output_file_type = 'tap'
 
-    if not OPTIONS.outputFileName:
-        OPTIONS.outputFileName = os.path.splitext(
-            os.path.basename(OPTIONS.inputFileName))[0] + os.path.extsep + OPTIONS.output_file_type
+    if not OPTIONS.output_filename:
+        OPTIONS.output_filename = os.path.splitext(
+            os.path.basename(OPTIONS.input_filename))[0] + os.path.extsep + OPTIONS.output_file_type
 
-    if OPTIONS.StdErrFileName:
-        OPTIONS.stderr = open(OPTIONS.StdErrFileName, 'wt')
+    if OPTIONS.stderr_filename:
+        OPTIONS.stderr = open(OPTIONS.stderr_filename, 'wt')
 
     if int(options.tzx) + int(options.tap) > 1:
         o_parser.error("Options --tap, --tzx and --asm are mutually exclusive")
         return 3
 
-    if OPTIONS.use_loader and not options.tzx and not options.tap:
+    if OPTIONS.use_basic_loader and not options.tzx and not options.tap:
         o_parser.error('Option --BASIC and --autorun requires --tzx or tap format')
         return 4
 
@@ -110,7 +110,7 @@ def main(args=None):
     zxbpp.setMode('asm')
 
     # Now filter them against the preprocessor
-    zxbpp.main([OPTIONS.inputFileName])
+    zxbpp.main([OPTIONS.input_filename])
 
     # Now output the result
     asm_output = zxbpp.OUTPUT
@@ -141,7 +141,7 @@ def main(args=None):
         with open(OPTIONS.memory_map, 'wt') as f:
             f.write(asmparse.MEMORY.memory_map)
 
-    asmparse.generate_binary(OPTIONS.outputFileName, OPTIONS.output_file_type)
+    asmparse.generate_binary(OPTIONS.output_filename, OPTIONS.output_file_type)
     return global_.has_errors
 
 

--- a/src/zxbc/args_parser.py
+++ b/src/zxbc/args_parser.py
@@ -24,11 +24,11 @@ def parser() -> argparse.ArgumentParser:
     )
     parser_.add_argument('PROGRAM', type=str,
                          help='BASIC program file')
-    parser_.add_argument('-d', '--debug', dest='debug', default=OPTIONS.Debug, action='count',
+    parser_.add_argument('-d', '--debug', dest='debug', default=OPTIONS.debug_level, action='count',
                          help='Enable verbosity/debugging output. Additional -d increase verbosity/debug level')
-    parser_.add_argument('-O', '--optimize', type=int, default=OPTIONS.optimization,
+    parser_.add_argument('-O', '--optimize', type=int, default=OPTIONS.optimization_level,
                          help='Sets optimization level. '
-                              '0 = None (default level is {0})'.format(OPTIONS.optimization))
+                              '0 = None (default level is {0})'.format(OPTIONS.optimization_level))
     parser_.add_argument('-o', '--output', type=str, dest='output_file', default=None,
                          help='Sets output file. Default is input filename with .bin extension')
     parser_.add_argument('-T', '--tzx', action='store_true',
@@ -43,7 +43,7 @@ def parser() -> argparse.ArgumentParser:
                          help="Sets output format to asm")
     parser_.add_argument('-S', '--org', type=str, default=str(OPTIONS.org),
                          help="Start of machine code. By default %i" % OPTIONS.org)
-    parser_.add_argument('-e', '--errmsg', type=str, dest='stderr', default=OPTIONS.StdErrFileName,
+    parser_.add_argument('-e', '--errmsg', type=str, dest='stderr', default=OPTIONS.stderr_filename,
                          help='Error messages file (standard error console by default)')
     parser_.add_argument('--array-base', type=int, default=OPTIONS.array_base,
                          help='Default lower index for arrays ({0} by default)'.format(OPTIONS.array_base))
@@ -90,7 +90,7 @@ def parser() -> argparse.ArgumentParser:
     parser_.add_argument('--arch', type=str, default=arch.AVAILABLE_ARCHITECTURES[0],
                          help=f"Target architecture (defaults is'{arch.AVAILABLE_ARCHITECTURES[0]}'). "
                               f"Available architectures: {','.join(arch.AVAILABLE_ARCHITECTURES)}")
-    parser_.add_argument('--expect-warnings', default=OPTIONS.expect_warnings, type=int,
+    parser_.add_argument('--expect-warnings', default=OPTIONS.expected_warnings, type=int,
                          help='Expects N warnings: first N warnings will be silenced')
     parser_.add_argument('-W', '--disable-warning', type=parse_warning_option, action='append',
                          help='Disables warning WXXX (i.e. -W100 disables warning with code W100)')

--- a/src/zxbc/zxbparser.py
+++ b/src/zxbc/zxbparser.py
@@ -304,7 +304,7 @@ def make_argument(expr, lineno, byref=None):
         return  # There were a syntax / semantic error
 
     if byref is None:
-        byref = OPTIONS.byref
+        byref = OPTIONS.default_byref
     return symbols.ARGUMENT(expr, lineno=lineno, byref=byref)
 
 
@@ -474,7 +474,7 @@ def make_break(lineno: int, p):
     checked """
     global last_brk_linenum
 
-    if not OPTIONS.enableBreak or lineno == last_brk_linenum or is_null(p):
+    if not OPTIONS.enable_break or lineno == last_brk_linenum or is_null(p):
         return None
 
     last_brk_linenum = lineno
@@ -3079,7 +3079,7 @@ def p_param_definition(p):
         if param_def.class_ == CLASS.array:
             param_def.byref = True
         else:
-            param_def.byref = OPTIONS.byref
+            param_def.byref = OPTIONS.default_byref
 
 
 def p_param_def_array(p):

--- a/src/zxbpp/zxbpp.py
+++ b/src/zxbpp/zxbpp.py
@@ -908,7 +908,7 @@ def entry_point(args=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('-o', '--output', type=str, dest='output_file', default=None,
                         help='Sets output file. Default is to output to console (STDOUT)')
-    parser.add_argument('-d', '--debug', dest='debug', default=config.OPTIONS.Debug, action='count',
+    parser.add_argument('-d', '--debug', dest='debug', default=config.OPTIONS.debug_level, action='count',
                         help='Enable verbosity/debugging output. Additional -d increases verbosity/debug level')
     parser.add_argument('-e', '--errmsg', type=str, dest='stderr', default=None,
                         help='Error messages file. Standard error console by default (STDERR)')
@@ -917,13 +917,13 @@ def entry_point(args=None):
     parser.add_argument('--arch', type=str, default=arch.AVAILABLE_ARCHITECTURES[0],
                         help=f"Target architecture (defaults is'{arch.AVAILABLE_ARCHITECTURES[0]}'). "
                              f"Available architectures: {','.join(arch.AVAILABLE_ARCHITECTURES)}")
-    parser.add_argument('--expect-warnings', default=config.OPTIONS.expect_warnings, type=int,
+    parser.add_argument('--expect-warnings', default=config.OPTIONS.expected_warnings, type=int,
                         help='Expects N warnings: first N warnings will be silenced')
 
     options = parser.parse_args(args=args)
-    config.OPTIONS.Debug = options.debug
-    config.OPTIONS.debug_zxbpp = config.OPTIONS.Debug > 0
-    config.OPTIONS.expect_warnings = options.expect_warnings
+    config.OPTIONS.debug_level = options.debug
+    config.OPTIONS.debug_zxbpp = config.OPTIONS.debug_level > 0
+    config.OPTIONS.expected_warnings = options.expect_warnings
 
     if options.arch not in arch.AVAILABLE_ARCHITECTURES:
         parser.error(f"Invalid architecture '{options.arch}'")
@@ -931,8 +931,8 @@ def entry_point(args=None):
     config.OPTIONS.architecture = options.arch
 
     if options.stderr:
-        config.OPTIONS.StdErrFileName = options.stderr
-        config.OPTIONS.stderr = utils.open_file(config.OPTIONS.StdErrFileName, 'wt', 'utf-8')
+        config.OPTIONS.stderr_filename = options.stderr
+        config.OPTIONS.stderr = utils.open_file(config.OPTIONS.stderr_filename, 'wt', 'utf-8')
 
     result = main([options.input_file] if options.input_file else [])
     if not global_.has_errors:  # ok?

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -3,6 +3,7 @@
 
 import unittest
 import sys
+
 from src.api import config, global_
 
 
@@ -14,29 +15,29 @@ class TestConfig(unittest.TestCase):
 
     def test_init(self):
         config.init()
-        self.assertEqual(config.OPTIONS.Debug, 0)
+        self.assertEqual(config.OPTIONS.debug_level, 0)
         self.assertEqual(config.OPTIONS.stdin, sys.stdin)
         self.assertEqual(config.OPTIONS.stdout, sys.stdout)
         self.assertEqual(config.OPTIONS.stderr, sys.stderr)
-        self.assertEqual(config.OPTIONS.optimization, global_.DEFAULT_OPTIMIZATION_LEVEL)
+        self.assertEqual(config.OPTIONS.optimization_level, global_.DEFAULT_OPTIMIZATION_LEVEL)
         self.assertEqual(config.OPTIONS.case_insensitive, False)
         self.assertEqual(config.OPTIONS.array_base, 0)
-        self.assertEqual(config.OPTIONS.byref, False)
+        self.assertEqual(config.OPTIONS.default_byref, False)
         self.assertEqual(config.OPTIONS.max_syntax_errors, global_.DEFAULT_MAX_SYNTAX_ERRORS)
         self.assertEqual(config.OPTIONS.string_base, 0)
         self.assertIsNone(config.OPTIONS.memory_map)
-        self.assertEqual(config.OPTIONS.bracket, False)
-        self.assertEqual(config.OPTIONS.use_loader, False)
+        self.assertEqual(config.OPTIONS.force_asm_brackets, False)
+        self.assertEqual(config.OPTIONS.use_basic_loader, False)
         self.assertEqual(config.OPTIONS.autorun, False)
         self.assertEqual(config.OPTIONS.output_file_type, 'bin')
         self.assertEqual(config.OPTIONS.include_path, '')
-        self.assertEqual(config.OPTIONS.memoryCheck, False)
-        self.assertEqual(config.OPTIONS.strictBool, False)
-        self.assertEqual(config.OPTIONS.arrayCheck, False)
-        self.assertEqual(config.OPTIONS.enableBreak, False)
-        self.assertEqual(config.OPTIONS.emitBackend, False)
+        self.assertEqual(config.OPTIONS.memory_check, False)
+        self.assertEqual(config.OPTIONS.strict_bool, False)
+        self.assertEqual(config.OPTIONS.array_check, False)
+        self.assertEqual(config.OPTIONS.enable_break, False)
+        self.assertEqual(config.OPTIONS.emit_backend, False)
         self.assertIsNone(config.OPTIONS.architecture)
-        self.assertEqual(config.OPTIONS.expect_warnings, 0)
+        self.assertEqual(config.OPTIONS.expected_warnings, 0)
 
         # private options that cannot be accessed with #pragma
         self.assertEqual(config.OPTIONS['__DEFINES'].value, {})
@@ -47,36 +48,36 @@ class TestConfig(unittest.TestCase):
     def test_initted_values(self):
         config.init()
         self.assertEqual(sorted(config.OPTIONS._options.keys()), [
-            'Debug',
             'Sinclair',
-            'StdErrFileName',
             '__DEFINES',
-            'architecture',
-            'arrayCheck',
-            'array_base',
-            'autorun',
-            'bracket',
-            'byref',
-            'case_insensitive',
-            'emitBackend',
-            'enableBreak',
-            'expect_warnings',
-            'explicit',
-            'hide_warning_codes',
-            'include_path',
-            'inputFileName',
-            'max_syntax_errors',
-            'memoryCheck',
-            'memory_map',
-            'optimization',
-            'outputFileName',
-            'output_file_type',
-            'stderr',
-            'stdin',
-            'stdout',
-            'strict',
-            'strictBool',
-            'string_base',
-            'use_loader',
-            'zxnext'
+            config.OPTION.ARCH,
+            config.OPTION.ARRAY_BASE,
+            config.OPTION.CHECK_ARRAYS,
+            config.OPTION.AUTORUN,
+            config.OPTION.CASE_INS,
+            config.OPTION.DEBUG,
+            config.OPTION.DEFAULT_BYREF,
+            config.OPTION.EMIT_BACKEND,
+            config.OPTION.ENABLE_BREAK,
+            config.OPTION.EXPECTED_WARNINGS,
+            config.OPTION.EXPLICIT,
+            config.OPTION.FORCE_ASM_BRACKET,
+            config.OPTION.HIDE_WARNING_CODES,
+            config.OPTION.INCLUDE_PATH,
+            config.OPTION.INPUT_FILENAME,
+            config.OPTION.MAX_SYN_ERRORS,
+            config.OPTION.CHECK_MEMORY,
+            config.OPTION.MEMORY_MAP,
+            config.OPTION.O_LEVEL,
+            config.OPTION.OUTPUT_FILE_TYPE,
+            config.OPTION.OUTPUT_FILENAME,
+            config.OPTION.STDERR,
+            config.OPTION.STDERR_FILENAME,
+            config.OPTION.STDIN,
+            config.OPTION.STDOUT,
+            config.OPTION.STRICT,
+            config.OPTION.STRICT_BOOL,
+            config.OPTION.STR_BASE,
+            config.OPTION.USE_BASIC_LOADER,
+            config.OPTION.ASM_ZXNEXT
         ])

--- a/tests/api/test_symbolTable.py
+++ b/tests/api/test_symbolTable.py
@@ -10,7 +10,7 @@ from src.api.constants import TYPE
 from src.api.constants import SCOPE
 from src.api.constants import CLASS
 from src.api.constants import DEPRECATED_SUFFIXES
-from src.api.config import OPTIONS
+from src.api.config import OPTIONS, OPTION
 import src.api.global_ as gl_
 from src import symbols
 
@@ -28,15 +28,15 @@ class TestSymbolTable(TestCase):
     def test__init__(self):
         """ Tests symbol table initialization
         """
-        OPTIONS['optimization'].push()
-        OPTIONS.optimization = 0
+        OPTIONS[OPTION.O_LEVEL].push()
+        OPTIONS.optimization_level = 0
         self.assertEqual(len(self.s.types), len(TYPE.types))
         for type_ in self.s.types:
             self.assertTrue(type_.is_basic)
             self.assertIsInstance(type_, symbols.BASICTYPE)
 
         self.assertEqual(self.s.current_scope, self.s.global_scope)
-        OPTIONS['optimization'].pop()
+        OPTIONS[OPTION.O_LEVEL].pop()
 
     def test_is_declared(self):
         # Checks variable 'a' is not declared yet

--- a/tests/functional/arrcheck.bas
+++ b/tests/functional/arrcheck.bas
@@ -1,4 +1,4 @@
-#pragma arrayCheck=true
+#pragma array_check=true
 #define __CHECK_ARRAY_BOUNDARY__
 
 DIM a(10, 5) as byte

--- a/tests/functional/break.bas
+++ b/tests/functional/break.bas
@@ -1,4 +1,4 @@
-#pragma enableBreak = true
+#pragma enable_break = true
 :REM Keyboard BREAK interrupt generation
 
 10 DIM a as UByte

--- a/tests/functional/strict_bool.bas
+++ b/tests/functional/strict_bool.bas
@@ -1,5 +1,5 @@
 
-#pragma strictBool=True
+#pragma strict_bool=True
 
 let a = a < 5
 


### PR DESCRIPTION
Use a centralized naming compatible with python ID names,
and defined sitematically.