### PR TITLE
fix: backlash continuation ignored after comment

### DIFF
--- a/src/zxbpp/zxbpplex.py
+++ b/src/zxbpp/zxbpplex.py
@@ -185,6 +185,13 @@ class Lexer(BaseLexer):
         t.value = t.value.strip()  # remove newline and spaces
         return t
 
+    def t_singlecomment_CONTINUE(self, t):
+        r"\\\r?\n"
+        t.lexer.lineno += 1
+        t.value = t.value[1:]
+        t.lexer.pop_state()
+        return t
+
     # Any other character is ignored until EOL
     def t_singlecomment_comment_Skip(self, t):
         r"."

--- a/tests/functional/prepro03.bi
+++ b/tests/functional/prepro03.bi
@@ -1,10 +1,7 @@
 
 #define test x 'a comment \
+    this line must be compiled
 #define test2 y ' This define should not be ignored
 
 test
 test2
-
-
-
-

--- a/tests/functional/prepro03.out
+++ b/tests/functional/prepro03.out
@@ -1,11 +1,9 @@
 #line 1 "prepro03.bi"
 
-#line 3 "prepro03.bi"
 #line 4 "prepro03.bi"
+#line 5 "prepro03.bi"
 
-x
+x 
+    this line must be compiled
+#line 7
 y
-
-
-
-

--- a/tests/functional/prepro80.bi
+++ b/tests/functional/prepro80.bi
@@ -7,5 +7,7 @@ REM simple WaitRetrace macro
 		halt \
 	end asm
 
-#endif
+waitretrace
+waitretrace
 
+#endif

--- a/tests/functional/prepro80.out
+++ b/tests/functional/prepro80.out
@@ -3,11 +3,18 @@
 
 
 
+
+
 	asm 
 		halt 
 		halt 
 	end asm
-#line 9
+#line 11
 
-#line 11 "prepro80.bi"
+	asm 
+		halt 
+		halt 
+	end asm
+#line 12
 
+#line 14 "prepro80.bi"


### PR DESCRIPTION
Lines having a line comment with REM or ' and ending in a backslash \ were not continued. Now they are. This allows setting comments within multiline #define macros