### PR TITLE
fix: fixes PEEK(ULong, ...)

### DIFF
--- a/src/arch/z80/backend/_32bit.py
+++ b/src/arch/z80/backend/_32bit.py
@@ -63,7 +63,7 @@ def _32bit_oper(op1, op2=None, *, reversed: bool = False, preserveHL: bool = Fal
     if immediate:
         op = op[1:]
 
-    hl = "hl" if not preserveHL and not indirect else "bc"
+    hl = "hl" if not preserveHL else "bc"
 
     if is_int(op):
         int1 = True

--- a/src/arch/z80/visitor/builtin_translator.py
+++ b/src/arch/z80/visitor/builtin_translator.py
@@ -57,7 +57,10 @@ class BuiltinTranslator(TranslatorVisitor):
         self.runtime_call(RuntimeLabel.RND, Type.float_.size)
 
     def visit_PEEK(self, node):
-        self.ic_load(node.type_, node.t, "*" + str(node.children[0].t))
+        if node.operand.token == "NUMBER":
+            self.ic_load(node.type_, node.t, "*#" + str(node.operand.t))
+        else:
+            self.ic_load(node.type_, node.t, "*" + str(node.operand.t))
 
     # region MATH Functions
     def visit_SIN(self, node):

--- a/tests/functional/zx48k/peek_ubyte.asm
+++ b/tests/functional/zx48k/peek_ubyte.asm
@@ -1,0 +1,50 @@
+	org 32768
+.core.__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (.core.__CALL_BACK__), hl
+	ei
+	jp .core.__MAIN_PROGRAM__
+.core.__CALL_BACK__:
+	DEFW 0
+.core.ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+.core.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_END - .core.ZXBASIC_USER_DATA
+	.core.__LABEL__.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_LEN
+	.core.__LABEL__.ZXBASIC_USER_DATA EQU .core.ZXBASIC_USER_DATA
+_x:
+	DEFB 00, 00
+_y:
+	DEFB 00
+.core.ZXBASIC_USER_DATA_END:
+.core.__MAIN_PROGRAM__:
+	ld a, (16384)
+	ld (_y), a
+	ld hl, (_x)
+	ld a, (hl)
+	ld (_y), a
+	ld hl, (_x)
+	ld a, (hl)
+	ld (_y), a
+	ld hl, 0
+	ld b, h
+	ld c, l
+.core.__END_PROGRAM:
+	di
+	ld hl, (.core.__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+	;; --- end of user code ---
+	END

--- a/tests/functional/zx48k/peek_ubyte.bas
+++ b/tests/functional/zx48k/peek_ubyte.bas
@@ -1,0 +1,6 @@
+DIM x as UInteger
+
+DIM y as UByte
+y = PEEK(UByte, 16384)
+y = PEEK(UByte, x)
+y = PEEK(UByte, x + 0)

--- a/tests/functional/zx48k/peek_uinteger.asm
+++ b/tests/functional/zx48k/peek_uinteger.asm
@@ -1,0 +1,56 @@
+	org 32768
+.core.__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (.core.__CALL_BACK__), hl
+	ei
+	jp .core.__MAIN_PROGRAM__
+.core.__CALL_BACK__:
+	DEFW 0
+.core.ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+.core.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_END - .core.ZXBASIC_USER_DATA
+	.core.__LABEL__.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_LEN
+	.core.__LABEL__.ZXBASIC_USER_DATA EQU .core.ZXBASIC_USER_DATA
+_x:
+	DEFB 00, 00
+_y:
+	DEFB 00, 00
+.core.ZXBASIC_USER_DATA_END:
+.core.__MAIN_PROGRAM__:
+	ld hl, (16384)
+	ld (_y), hl
+	ld hl, (_x)
+	ld a, (hl)
+	inc hl
+	ld h, (hl)
+	ld l, a
+	ld (_y), hl
+	ld hl, (_x)
+	ld a, (hl)
+	inc hl
+	ld h, (hl)
+	ld l, a
+	ld (_y), hl
+	ld hl, 0
+	ld b, h
+	ld c, l
+.core.__END_PROGRAM:
+	di
+	ld hl, (.core.__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+	;; --- end of user code ---
+	END

--- a/tests/functional/zx48k/peek_uinteger.bas
+++ b/tests/functional/zx48k/peek_uinteger.bas
@@ -1,0 +1,6 @@
+DIM x as UInteger
+
+DIM y as UInteger
+y = PEEK(UInteger, 16384)
+y = PEEK(UInteger, x)
+y = PEEK(UInteger, x + 0)

--- a/tests/functional/zx48k/peek_ulong.asm
+++ b/tests/functional/zx48k/peek_ulong.asm
@@ -1,0 +1,73 @@
+	org 32768
+.core.__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (.core.__CALL_BACK__), hl
+	ei
+	jp .core.__MAIN_PROGRAM__
+.core.__CALL_BACK__:
+	DEFW 0
+.core.ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+.core.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_END - .core.ZXBASIC_USER_DATA
+	.core.__LABEL__.ZXBASIC_USER_DATA_LEN EQU .core.ZXBASIC_USER_DATA_LEN
+	.core.__LABEL__.ZXBASIC_USER_DATA EQU .core.ZXBASIC_USER_DATA
+_x:
+	DEFB 00, 00
+_y:
+	DEFB 00, 00, 00, 00
+.core.ZXBASIC_USER_DATA_END:
+.core.__MAIN_PROGRAM__:
+	ld hl, 16384
+	call .core.__ILOAD32
+	ld (_y), hl
+	ld (_y + 2), de
+	ld hl, (_x)
+	call .core.__ILOAD32
+	ld (_y), hl
+	ld (_y + 2), de
+	ld hl, (_x)
+	call .core.__ILOAD32
+	ld (_y), hl
+	ld (_y + 2), de
+	ld hl, 0
+	ld b, h
+	ld c, l
+.core.__END_PROGRAM:
+	di
+	ld hl, (.core.__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	exx
+	pop iy
+	pop ix
+	ei
+	ret
+	;; --- end of user code ---
+#line 1 "/zxbasic/src/arch/zx48k/library-asm/iload32.asm"
+	; __FASTCALL__ routine which
+	; loads a 32 bits integer into DE,HL
+	; stored at position pointed by POINTER HL
+	; DE,HL <-- (HL)
+	    push namespace core
+__ILOAD32:
+	    ld e, (hl)
+	    inc hl
+	    ld d, (hl)
+	    inc hl
+	    ld a, (hl)
+	    inc hl
+	    ld h, (hl)
+	    ld l, a
+	    ex de, hl
+	    ret
+	    pop namespace
+#line 29 "peek_ulong.bas"
+	END

--- a/tests/functional/zx48k/peek_ulong.bas
+++ b/tests/functional/zx48k/peek_ulong.bas
@@ -1,0 +1,6 @@
+DIM x as UInteger
+
+DIM y as ULong
+y = PEEK(ULong, 16384)
+y = PEEK(ULong, x)
+y = PEEK(ULong, x + 0)


### PR DESCRIPTION
This implementation was wrong due to a edge case with iload32 IC translation.