### PR TITLE
feat: do not crash in older Python versions

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,7 +6,7 @@ PYTHON_VERSION = 3, 10  # Minimum python version required
 
 if tuple(sys.version_info) < PYTHON_VERSION:
     print(
-        f"{sys.argv[0]} Error: minimum Python Version required is {'.'.join(str(x) for x in PYTHON_VERSION)}",
+        "%s Error: require Python version %s or higher" % (sys.argv[0], (".".join(str(x) for x in PYTHON_VERSION))),
         file=sys.stderr,
     )
     sys.exit(1)


### PR DESCRIPTION
For Python < 3.6 (at least) the error message
saying the Python version is unsupported crashed, because older versions do not support f-strings.