### PR TITLE
feat: shows error message in Python 2.x

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,8 +5,8 @@ import sys
 PYTHON_VERSION = 3, 10  # Minimum python version required
 
 if tuple(sys.version_info) < PYTHON_VERSION:
-    print(
-        "%s Error: require Python version %s or higher" % (sys.argv[0], (".".join(str(x) for x in PYTHON_VERSION))),
-        file=sys.stderr,
+    sys.stderr.write(
+        "%s Error: Python version %s or higher is required\n"
+        % (sys.argv[0], (".".join(str(x) for x in PYTHON_VERSION)))
     )
     sys.exit(1)


### PR DESCRIPTION
This fix will correctly display the message error
when a (very) old (Python 2.x) version of Python is used.